### PR TITLE
Playtime false negatives

### DIFF
--- a/Do You Even Play, Bro.user.js
+++ b/Do You Even Play, Bro.user.js
@@ -220,18 +220,18 @@ var updateTableStats = function() {
     } else {
         $percentage.text("N/A");
     }
-    if(playtime_game_count !== win_count) {
-        $average_playtime.text(formatMinutes(playtime_total / win_count) + " per win, " + formatMinutes(playtime_total / playtime_game_count) + " per played win");
+    if(playtime_game_count !== reports_playtime_game_count) {
+        $average_playtime.text(formatMinutes(playtime_total / reports_playtime_game_count) + " per win, " + formatMinutes(playtime_total / playtime_game_count) + " per played win");
     } else {
-        $average_playtime.text(formatMinutes(playtime_total / win_count) + " in all wins");
+        $average_playtime.text(formatMinutes(playtime_total / reports_playtime_game_count) + " in all wins");
     }
     $total_playtime.text(formatMinutes(playtime_total));
-    $playtime_counts.text('any playtime: ' + formatPercentage(playtime_game_count, win_count, 3) +
-                          ' (' + playtime_game_count + '/' + win_count + '), ≥2 hours: ' +
-                          formatPercentage(playtime_game_count_2h, win_count, 3) +
-                          ' (' + playtime_game_count_2h + '/' + win_count + '), ≥10 hours: '+
-                          formatPercentage(playtime_game_count_10h, win_count, 3) +
-                          ' (' + playtime_game_count_10h + '/' + win_count + ')');
+    $playtime_counts.text('any playtime: ' + formatPercentage(playtime_game_count, reports_playtime_game_count, 3) +
+                          ' (' + playtime_game_count + '/' + reports_playtime_game_count + '), ≥2 hours: ' +
+                          formatPercentage(playtime_game_count_2h, reports_playtime_game_count, 3) +
+                          ' (' + playtime_game_count_2h + '/' + reports_playtime_game_count + '), ≥10 hours: '+
+                          formatPercentage(playtime_game_count_10h, reports_playtime_game_count, 3) +
+                          ' (' + playtime_game_count_10h + '/' + reports_playtime_game_count + ')');
     $achievement_counts.text('≥1: ' + formatPercentage(achieved_game_count, achievement_game_count, 3) +
                              ' (' + achieved_game_count + '/' + achievement_game_count + '), ≥25%: ' +
                             formatPercentage(achieved_game_count_25, achievement_game_count, 3) +

--- a/Do You Even Play, Bro.user.js
+++ b/Do You Even Play, Bro.user.js
@@ -179,7 +179,7 @@ var enhanceWonGames = function() {
 var updateTableStats = function() {
     var achievement_percentage_sum = 0, achievement_game_count = 0, achieved_game_count = 0,
         achieved_game_count_25 = 0, achieved_game_count_100 = 0,
-        playtime_total = 0, playtime_game_count = 0, playtime_game_count_2h = 0, playtime_game_count_10h = 0,
+        playtime_total = 0, playtime_game_count = 0, playtime_game_count_2h = 0, playtime_game_count_10h = 0, reports_playtime_game_count = 0,
         win_count = 0, achievement_playtime_total = 0, achievement_playtime_count = 0;
     $.each(winsCache, function(aid, appid) {
         win_count += 1;
@@ -197,14 +197,17 @@ var updateTableStats = function() {
                 }
             }
         }
-        if(playtimeCache[aid]) {
-            playtime_total += playtimeCache[aid];
-            playtime_game_count += 1;
-            if(playtimeCache[aid] >= 120) {
-                playtime_game_count_2h += 1;
-            }
-            if(playtimeCache[aid] >= 600) {
-                playtime_game_count_10h += 1;
+        if (playtimeCache[aid] !== undefined) {
+            reports_playtime_game_count += 1
+            if(playtimeCache[aid]) {
+                playtime_total += playtimeCache[aid];
+                playtime_game_count += 1;
+                if(playtimeCache[aid] >= 120) {
+                    playtime_game_count_2h += 1;
+                }
+                if(playtimeCache[aid] >= 600) {
+                    playtime_game_count_10h += 1;
+                }
             }
         }
         if(achievement_counts && achievement_counts.total > 0 && playtimeCache[aid]) {


### PR DESCRIPTION
Hi kelnage,

I noticed a way to avoid including wins which don't report playtime (DLCs, etc) from adding false negatives to a users playtime stats. Basically, your playtimeCache contains 0 for games which have no playtime but undefined for games that don't report playtime at all.

Here's a version I made which reports playtime stats based only on games which report playtime, so that should avoid most false positives.